### PR TITLE
make accesslog order stable (#54680)

### DIFF
--- a/pilot/pkg/model/telemetry.go
+++ b/pilot/pkg/model/telemetry.go
@@ -279,6 +279,11 @@ func (t *Telemetries) AccessLogging(push *PushContext, proxy *Proxy, class netwo
 		cfgs = append(cfgs, cfg)
 	}
 
+	// Sort the access logs by provider name for deterministic ordering
+	sort.Slice(cfgs, func(i, j int) bool {
+		return cfgs[i].Provider.Name < cfgs[j].Provider.Name
+	})
+
 	t.computedLoggingConfig[key] = cfgs
 	return cfgs
 }

--- a/pilot/pkg/model/telemetry_logging_test.go
+++ b/pilot/pkg/model/telemetry_logging_test.go
@@ -16,7 +16,6 @@ package model
 
 import (
 	"reflect"
-	"sort"
 	"testing"
 
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -705,7 +704,6 @@ func TestAccessLogging(t *testing.T) {
 					}
 					got = append(got, p.Provider.Name)
 				}
-				sort.Strings(got)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("got %v want %v", got, tt.want)

--- a/releasenotes/notes/54680.yaml
+++ b/releasenotes/notes/54680.yaml
@@ -1,0 +1,8 @@
+apiVersion: release-notes/v2
+kind: bug-fix
+area: telemetry
+issue:
+  - 54672
+releaseNotes:
+  - |
+    **Fixed** an issue that access log order instability causing connection draining.


### PR DESCRIPTION
Cherry picks https://github.com/istio/istio/pull/54680 to 1.23.4