### PR TITLE
monitoring: increase pilot_debounce_time buckets

### DIFF
--- a/pilot/pkg/xds/monitoring.go
+++ b/pilot/pkg/xds/monitoring.go
@@ -57,7 +57,7 @@ var (
 	debounceTime = monitoring.NewDistribution(
 		"pilot_debounce_time",
 		"Delay in seconds between the first config enters debouncing and the merged push request is pushed into the push queue.",
-		[]float64{.01, .1, 1, 3, 5, 10, 20, 30},
+		[]float64{1, 5, 10, 20, 30, 40, 50, 60},
 	)
 
 	pushContextInitTime = monitoring.NewDistribution(


### PR DESCRIPTION
This CL increases the pilot_debounce_time histogram buckets. As our debounce time is often > 30s, we'd like to increase the fidelity in our metric in order to more accurately report on our SLO. See https://docs.google.com/document/d/1PvFrOp2GxwP9RRL0iXmFHtSYyqf8bs7Y56E93ncmRFg

Change-Id: I996a7f2a551a913798f46178449adb5b1a13d427
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/5526
Reviewed-by: Edie Yang <edie.yang@airbnb.com>
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/6013
Reviewed-by: Douglas Jordan <douglas.jordan@airbnb.com>

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
