### PR TITLE
istio: fix debounce metrics

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -344,7 +344,6 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts DebounceO
 	push := func(req *model.PushRequest, debouncedEvents int, startDebounce time.Time) {
 		pushFn(req)
 		updateSent.Add(int64(debouncedEvents))
-		debounceTime.Record(time.Since(startDebounce).Seconds())
 		freeCh <- struct{}{}
 	}
 
@@ -364,6 +363,7 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts DebounceO
 						pushCounter, debouncedEvents, configsUpdated(req),
 						quietTime, eventDelay, req.Full)
 				}
+				debounceTime.Record(eventDelay.Seconds())
 				free = false
 				go push(req, debouncedEvents, startDebounce)
 				req = nil


### PR DESCRIPTION
The debounce metric should be emitted when we set the free to false, and reset the debounced events to 0, because that's when the next startDebounce starts counting.

Change-Id: Ic2c99632f10f0440f5d302ee5cd5385bc6aa6834
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/4583
Reviewed-by: Douglas Jordan <douglas.jordan@airbnb.com>
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/7215

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
