### PR TITLE
protocol: fallback to tcp ports instead of unsupported.

### DIFF
--- a/pkg/config/protocol/instance_test.go
+++ b/pkg/config/protocol/instance_test.go
@@ -58,9 +58,9 @@ func TestParse(t *testing.T) {
 		{"mysql", protocol.MySQL},
 		{"MYSQL", protocol.MySQL},
 		{"MySQL", protocol.MySQL},
-		{"", protocol.Unsupported},
-		{"SMTP", protocol.Unsupported},
-		{"HBONE", protocol.Unsupported},
+		{"", protocol.TCP},
+		{"SMTP", protocol.TCP},
+		{"HBONE", protocol.TCP},
 	}
 
 	for _, testPair := range testPairs {


### PR DESCRIPTION
As suggested in the Istio slack, this hack is due to the fact that the flag to remove protocol sniffing was removed.

Change-Id: Ic5c34cf11770bcf4fc844f8d674643a52ce62f78
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/6343
Reviewed-by: Bhasker Hariharan <bhasker.hariharan@airbnb.com>
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/7211
Reviewed-by: Douglas Jordan <douglas.jordan@airbnb.com>

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
