### PR TITLE
authz/matcher: fix unit tests

### DIFF
--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -20,6 +20,7 @@ import (
 
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 )


### PR DESCRIPTION
This PR fixes the TestHeaderMatcher unittests.

Tested with
```
go test istio.io/istio/pilot/pkg/security/authz/matcher
ok      istio.io/istio/pilot/pkg/security/authz/matcher 0.416s
```