### PR TITLE
istio: support inline multi-values header in authz header match

### DIFF
--- a/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/allow-full-rule-out.yaml
@@ -522,16 +522,19 @@ typedConfig:
                 ids:
                 - header:
                     name: X-header
-                    stringMatch:
-                      exact: header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
-                    stringMatch:
-                      prefix: header-prefix-
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
-                    stringMatch:
-                      suffix: -suffix-header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true
@@ -540,16 +543,19 @@ typedConfig:
                   ids:
                   - header:
                       name: X-header
-                      stringMatch:
-                        exact: not-header
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^not-header$|^not-header,.*|.*,not-header,.*|.*,not-header$
                   - header:
                       name: X-header
-                      stringMatch:
-                        prefix: not-header-prefix-
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^not-header-prefix-.*$|^not-header-prefix-.*,.*|.*,not-header-prefix-.*,.*|.*,not-header-prefix-.*$
                   - header:
                       name: X-header
-                      stringMatch:
-                        suffix: -not-suffix-header
+                      safeRegexMatch:
+                        googleRe2: {}
+                        regex: ^.*-not-suffix-header$|^.*-not-suffix-header,.*|.*,.*-not-suffix-header,.*|.*,.*-not-suffix-header$
                   - header:
                       name: X-header
                       presentMatch: true

--- a/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/multiple-policies-out.yaml
@@ -177,10 +177,12 @@ typedConfig:
                 ids:
                 - header:
                     name: X-abc
-                    stringMatch:
-                      exact: abc1
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^abc1$|^abc1,.*|.*,abc1,.*|.*,abc1$
                 - header:
                     name: X-abc
-                    stringMatch:
-                      exact: abc2
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^abc2$|^abc2,.*|.*,abc2,.*|.*,abc2$
   shadowRulesStatPrefix: istio_dry_run_allow_

--- a/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
+++ b/pilot/pkg/security/authz/builder/testdata/http/single-policy-out.yaml
@@ -169,16 +169,19 @@ typedConfig:
                 ids:
                 - header:
                     name: X-header
-                    stringMatch:
-                      exact: header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
-                    stringMatch:
-                      prefix: header-prefix-
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
-                    stringMatch:
-                      suffix: -suffix-header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true
@@ -268,16 +271,19 @@ typedConfig:
                 ids:
                 - header:
                     name: X-header
-                    stringMatch:
-                      exact: header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header$|^header,.*|.*,header,.*|.*,header$
                 - header:
                     name: X-header
-                    stringMatch:
-                      prefix: header-prefix-
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^header-prefix-.*$|^header-prefix-.*,.*|.*,header-prefix-.*,.*|.*,header-prefix-.*$
                 - header:
                     name: X-header
-                    stringMatch:
-                      suffix: -suffix-header
+                    safeRegexMatch:
+                      googleRe2: {}
+                      regex: ^.*-suffix-header$|^.*-suffix-header,.*|.*,.*-suffix-header,.*|.*,.*-suffix-header$
                 - header:
                     name: X-header
                     presentMatch: true

--- a/pilot/pkg/security/authz/matcher/header.go
+++ b/pilot/pkg/security/authz/matcher/header.go
@@ -15,6 +15,8 @@
 package matcher
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -85,6 +87,40 @@ func HostMatcher(k, v string) *routepb.HeaderMatcher {
 		Name: k,
 		HeaderMatchSpecifier: &routepb.HeaderMatcher_StringMatch{
 			StringMatch: StringMatcherExact(v, true),
+		},
+	}
+}
+
+// HeaderMatcherWithRegex converts a key, value string pair to a corresponding
+// HeaderMatcher using regex to support the inline multi-values header that is
+// concatenated by commas, as per RFC7230.
+func HeaderMatcherWithRegex(k, v string) *routepb.HeaderMatcher {
+	// We must check "*" first to distinguish present match from the other
+	// cases.
+	var regex string
+	if v == "*" {
+		return &routepb.HeaderMatcher{
+			Name: k,
+			HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
+				PresentMatch: true,
+			},
+		}
+	} else if strings.HasPrefix(v, "*") {
+		regex = `.*` + regexp.QuoteMeta(v[1:])
+	} else if strings.HasSuffix(v, "*") {
+		regex = regexp.QuoteMeta(v[:len(v)-1]) + `.*`
+	} else {
+		regex = regexp.QuoteMeta(v)
+	}
+	return &routepb.HeaderMatcher{
+		Name: k,
+		HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+			SafeRegexMatch: &matcher.RegexMatcher{
+				EngineType: &matcher.RegexMatcher_GoogleRe2{
+					GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
+				},
+				Regex: fmt.Sprintf(`^%s$|^%s,.*|.*,%s,.*|.*,%s$`, regex, regex, regex, regex),
+			},
 		},
 	}
 }

--- a/pilot/pkg/security/authz/matcher/header_test.go
+++ b/pilot/pkg/security/authz/matcher/header_test.go
@@ -149,6 +149,82 @@ func TestHostMatcher(t *testing.T) {
 	}
 }
 
+func TestHeaderMatcherWithRegex(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		K      string
+		V      string
+		Expect *routepb.HeaderMatcher
+	}{
+		{
+			Name: "exact match",
+			K:    ":path",
+			V:    "/productpage",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcherpb.RegexMatcher{
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+						Regex: "^/productpage$|^/productpage,.*|.*,/productpage,.*|.*,/productpage$",
+					},
+				},
+			},
+		},
+		{
+			Name: "suffix match",
+			K:    ":path",
+			V:    "*/productpage*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcherpb.RegexMatcher{
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+						Regex: `^.*/productpage\*$|^.*/productpage\*,.*|.*,.*/productpage\*,.*|.*,.*/productpage\*$`,
+					},
+				},
+			},
+		},
+		{
+			Name: "prefix match",
+			K:    ":path",
+			V:    "/productpage*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_SafeRegexMatch{
+					SafeRegexMatch: &matcherpb.RegexMatcher{
+						EngineType: &matcherpb.RegexMatcher_GoogleRe2{
+							GoogleRe2: &matcherpb.RegexMatcher_GoogleRE2{},
+						},
+						Regex: `^/productpage.*$|^/productpage.*,.*|.*,/productpage.*,.*|.*,/productpage.*$`,
+					},
+				},
+			},
+		},
+		{
+			Name: "present match",
+			K:    ":path",
+			V:    "*",
+			Expect: &routepb.HeaderMatcher{
+				Name: ":path",
+				HeaderMatchSpecifier: &routepb.HeaderMatcher_PresentMatch{
+					PresentMatch: true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := HeaderMatcherWithRegex(tc.K, tc.V)
+		if !cmp.Equal(tc.Expect, actual, protocmp.Transform()) {
+			t.Errorf("expecting %v, but got %v", tc.Expect, actual)
+		}
+	}
+}
+
 func TestPathMatcher(t *testing.T) {
 	testCases := []struct {
 		Name   string

--- a/pilot/pkg/security/authz/model/generator.go
+++ b/pilot/pkg/security/authz/model/generator.go
@@ -332,7 +332,8 @@ func (requestHeaderGenerator) principal(key, value string, forTCP bool, _ bool) 
 	if err != nil {
 		return nil, err
 	}
-	m := matcher.HeaderMatcher(header, value)
+
+	m := matcher.HeaderMatcherWithRegex(header, value)
 	return principalHeader(m), nil
 }
 

--- a/pilot/pkg/security/authz/model/generator_test.go
+++ b/pilot/pkg/security/authz/model/generator_test.go
@@ -374,8 +374,9 @@ func TestGenerator(t *testing.T) {
 			want: yamlPrincipal(t, `
         header:
           name: x-foo
-          stringMatch:
-            exact: foo`),
+          safeRegexMatch:
+            googleRe2: {}
+            regex: ^foo$|^foo,.*|.*,foo,.*|.*,foo$`),
 		},
 		{
 			name:  "hostGenerator",


### PR DESCRIPTION
This CL supports inline multi-values header in the AuthzPolicy header match in Istio by using the Envoy safe regex match.

Note that only developer access traffic will be using this header match AuthzPolicy.

See the design doc: https://docs.google.com/document/d/1Q8mkHOwkL76ciQr27uXRQVi_pFWV3yB2eDRQpKp5pPs/edit#heading=h.3labvasnbv1d

Change-Id: Ieee91cae196b2f9b57796115a71543cef199dc0d
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/3622
Reviewed-by: Ying Zhu <ying.zhu@airbnb.com>
Reviewed-by: Douglas Jordan <redacted>
Reviewed-by: Weibo He <weibo.he@airbnb.com>
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/7210
Reviewed-by: Edie Yang <edie.yang@airbnb.com>
