### PR TITLE
istio: fix debounce metrics

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -348,7 +348,6 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts DebounceO
 	push := func(req *model.PushRequest, debouncedEvents int, startDebounce time.Time) {
 		pushFn(req)
 		updateSent.Add(int64(debouncedEvents))
-		debounceTime.Record(time.Since(startDebounce).Seconds())
 		freeCh <- struct{}{}
 	}
 
@@ -368,6 +367,7 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts DebounceO
 						pushCounter, debouncedEvents, configsUpdated(req),
 						quietTime, eventDelay, req.Full)
 				}
+				debounceTime.Record(eventDelay.Seconds())
 				free = false
 				go push(req, debouncedEvents, startDebounce)
 				req = nil


### PR DESCRIPTION
The debounce metric should be emitted when we set the free to false, and reset the debounced events to 0, because that's when the next startDebounce starts counting.

Change-Id: Ic2c99632f10f0440f5d302ee5cd5385bc6aa6834
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/4583
Reviewed-by: Douglas Jordan <douglas.jordan@airbnb.com>
Reviewed-on: https://gerrit.musta.ch/c/public/istio/+/7215