### PR TITLE
istio: include cellauth in istiod image

### DIFF
--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -11,12 +11,17 @@ FROM ${ISTIO_BASE_REGISTRY}/base:${BASE_VERSION} AS debug
 # The following section is used as base image if BASE_DISTRIBUTION=distroless
 FROM ${ISTIO_BASE_REGISTRY}/distroless:${BASE_VERSION} AS distroless
 
+# Install cellauth
+FROM 172631448019.dkr.ecr.us-east-1.amazonaws.com/ubuntu2204:2025-05-01-daily AS cellauth
+RUN /jorb/scripts/install-tool.sh cellauth
+
 # This will build the final image based on either debug or distroless from above
 # hadolint ignore=DL3006
 FROM ${BASE_DISTRIBUTION:-debug}
 
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/pilot-discovery /usr/local/bin/pilot-discovery
+COPY --from=cellauth /usr/local/bin/cellauth /usr/local/bin/cellauth
 
 USER 1337:1337
 


### PR DESCRIPTION
**Please provide a description of this PR:**

Cherry-pick of the airbnb fork patch \`include cellauth in istiod image\` onto the 1.28.8 release branch, for the 1.25.3 → 1.28.8 upgrade.

- Cherry-picked SHA (off air-release-1.25.3-airbnb1): \`eb6a2f4335\`
- Prior PR: https://github.com/airbnb/istio/pull/29
- Applied cleanly (no conflicts).

**Test plan:** Tested by running cellauth in the istiod image and verifying that it works as expected.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Control Plane Revisions
- [X] Test and Release

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any user-facing changes.