### PR TITLE
istio: fix debounce metrics

### DIFF
--- a/pilot/pkg/xds/discovery.go
+++ b/pilot/pkg/xds/discovery.go
@@ -345,7 +345,6 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts DebounceO
 	push := func(req *model.PushRequest, debouncedEvents int, startDebounce time.Time) {
 		pushFn(req)
 		updateSent.Add(int64(debouncedEvents))
-		debounceTime.Record(time.Since(startDebounce).Seconds())
 		freeCh <- struct{}{}
 	}
 
@@ -365,6 +364,7 @@ func debounce(ch chan *model.PushRequest, stopCh <-chan struct{}, opts DebounceO
 						pushCounter, debouncedEvents, configsUpdated(req),
 						quietTime, eventDelay, req.Full)
 				}
+				debounceTime.Record(eventDelay.Seconds())
 				free = false
 				go push(req, debouncedEvents, startDebounce)
 				req = nil


### PR DESCRIPTION
**Please provide a description of this PR:**

Cherry-pick of the airbnb fork patch \`fix-debounce-metrics\` onto the 1.28.8 release branch, for the 1.25.3 → 1.28.8 upgrade. The debounce metric is emitted when free is set to false and debounced events reset to 0, i.e. when the next startDebounce begins counting.

- Cherry-picked SHA (off air-release-1.25.3-airbnb1): \`ee31180611\`
- Prior PR: https://gerrit.musta.ch/c/public/istio/+/4583
- Applied cleanly (no conflicts).

**Test plan:** Tested manually by looking at the metrics in the test mesh.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [X] Does not have any user-facing changes.