### PR TITLE
protocol: fallback to tcp ports instead of unsupported

### DIFF
--- a/pkg/config/protocol/instance.go
+++ b/pkg/config/protocol/instance.go
@@ -95,7 +95,22 @@ func Parse(s string) Instance {
 		return DoubleHBONE
 	}
 
-	return Unsupported
+	// This hack is due to the fact that we do not rely on protocol detection.
+	//
+	// Unknown protocol ports get programmed by Istiod with both TLS and HTTP
+	// inspectors and a full HTTP chain. Which is by design but is a problem
+	// for us as there are a lot of applications that expose non-mesh TCP ports
+	// which get pushed as listeners to sidecars but are never used as the
+	// clusterIPs associated are the workload cluster's serviceIPs.
+	// This can result in a substantial amount of memory increase for services
+	// with many outbound dependencies.
+	//
+	// By treating unnamed ports as TCP instead of Unsupported it prevents
+	// istiod from building an HTTP filter chain reverting us to the 1.17
+	// behavior of treating these ports as TCP and essentially disables
+	// protocol sniffing on these ports and stops Istiod from adding a full
+	// HTTP filter chain
+	return TCP
 }
 
 // IsHTTP2 is true for protocols that use HTTP/2 as transport protocol

--- a/pkg/config/protocol/instance_test.go
+++ b/pkg/config/protocol/instance_test.go
@@ -58,9 +58,9 @@ func TestParse(t *testing.T) {
 		{"mysql", protocol.MySQL},
 		{"MYSQL", protocol.MySQL},
 		{"MySQL", protocol.MySQL},
-		{"", protocol.Unsupported},
-		{"SMTP", protocol.Unsupported},
-		{"HBONE", protocol.Unsupported},
+		{"", protocol.TCP},
+		{"SMTP", protocol.TCP},
+		{"HBONE", protocol.TCP},
 	}
 
 	for _, testPair := range testPairs {


### PR DESCRIPTION
**Please provide a description of this PR:**

Cherry-pick of the airbnb fork patch \`protocol: fallback to tcp ports instead of unsupported\` onto the 1.28.8 release branch, for the 1.25.3 → 1.28.8 upgrade. Works around removal of the protocol-sniffing disable flag by falling back to tcp for unsupported ports.

- Cherry-picked SHA (off air-release-1.25.3-airbnb1): \`eb96c031df\`
- Prior PR: https://gerrit.musta.ch/c/public/istio/+/6343
- Applied cleanly (no conflicts).

**Test plan:** Tested during the 1.19 rollout.

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [X] Networking

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes.